### PR TITLE
specify pertino client version

### DIFF
--- a/libraries/provider_pertino_client.rb
+++ b/libraries/provider_pertino_client.rb
@@ -30,6 +30,7 @@ class Chef
           # to prevent misbehaving, and allows for any variant of 32-bit.
           arch 'x86_64' if platform_family?('rhel') && node['kernel']['machine'] == 'x86_64'
           action :install
+          version '590-4651'
         end
 
         # Authenticate the Pertino Client via method specified


### PR DESCRIPTION
older versions don't work with this cookbook.

the pauth command is working with this version:

```
[staging]jim@i-622d0674:bill:~$ sudo apt-cache showpkg pertino-client
Package: pertino-client
Versions:
590-4651 (/var/lib/apt/lists/reposerver.pertino.com_debs_dists_precise_multiverse_binary-amd64_Packages) (/var/lib/dpkg/status)
 Description Language:
                 File: /var/lib/apt/lists/reposerver.pertino.com_debs_dists_precise_multiverse_binary-amd64_Packages
                  MD5: e4bdb26465c572dbdcccaa367beeaaed


Reverse Depends:
Dependencies:
590-4651 - libc6 (2 2.15) debconf (0 (null))
Provides:
590-4651 -
Reverse Provides:
```
